### PR TITLE
Change `Symbol#to_bool` to be case-insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Call `to_bool` on any object. It will *usually* return false, except:
 * String: `"true"`, `"1"`, and `"yes"` are true
 * Integer: `1` is true
 * TrueClass: `true` is true
-* Symbol: :true is true
+* Symbol: `:true` is true
 
 See the spec, it pretty much maps it out.
 

--- a/lib/to_bool.rb
+++ b/lib/to_bool.rb
@@ -3,7 +3,7 @@ class String
     %w{ 1 true yes t }.include? self.downcase
   end
 
-  alias_method :to_boolean, :to_bool
+  alias to_boolean to_bool
 end
 
 class Integer
@@ -11,7 +11,7 @@ class Integer
     self == 1
   end
 
-  alias_method :to_boolean, :to_bool
+  alias to_boolean to_bool
 end
 
 
@@ -20,7 +20,7 @@ class TrueClass
     self
   end
 
-  alias_method :to_boolean, :to_bool
+  alias to_boolean to_bool
 end
 
 class Object
@@ -28,7 +28,7 @@ class Object
     false
   end
 
-  alias_method :to_boolean, :to_bool
+  alias to_boolean to_bool
 end
 
 class Symbol
@@ -36,5 +36,5 @@ class Symbol
     self.downcase == :true
   end
 
-  alias_method :to_boolean, :to_bool
+  alias to_boolean to_bool
 end

--- a/lib/to_bool.rb
+++ b/lib/to_bool.rb
@@ -33,7 +33,7 @@ end
 
 class Symbol
   def to_bool
-    self == :true
+    self.downcase == :true
   end
 
   alias_method :to_boolean, :to_bool

--- a/spec/to_bool_spec.rb
+++ b/spec/to_bool_spec.rb
@@ -64,6 +64,10 @@ describe "Symbol" do
     expect(:true.to_bool).to eq true
   end
 
+  it "is true if :TRUE" do
+    expect(:TRUE.to_bool).to eq true
+  end
+
   it "is false otherwise" do
     expect(:false.to_bool).to eq false
     expect(:hoge.to_bool).to eq false

--- a/spec/to_bool_spec.rb
+++ b/spec/to_bool_spec.rb
@@ -22,6 +22,14 @@ describe "String" do
     expect("TRUE".to_bool).to eq true
   end
 
+  it "is true if 't'" do
+    expect("t".to_bool).to eq true
+  end
+
+  it "is true if 'T'" do
+    expect("T".to_bool).to eq true
+  end
+
   it "is false otherwise" do
     expect("no".to_bool).to eq false
     expect("false".to_bool).to eq false

--- a/spec/to_bool_spec.rb
+++ b/spec/to_bool_spec.rb
@@ -5,15 +5,23 @@ describe "String" do
   it "is true if yes" do
     expect("yes".to_bool).to eq true
   end
-  
+
+  it "is true if YES" do
+    expect("YES".to_bool).to eq true
+  end
+
   it "is true if '1'" do
     expect("1".to_bool).to eq true
   end
-  
+
   it "is true if 'true'" do
     expect("true".to_bool).to eq true
   end
-  
+
+  it "is true if 'TRUE'" do
+    expect("TRUE".to_bool).to eq true
+  end
+
   it "is false otherwise" do
     expect("no".to_bool).to eq false
     expect("false".to_bool).to eq false

--- a/spec/to_bool_spec.rb
+++ b/spec/to_bool_spec.rb
@@ -2,11 +2,11 @@ require 'bundler/setup'
 Bundler.require
 
 describe "String" do
-  it "is true if yes" do
+  it "is true if 'yes'" do
     expect("yes".to_bool).to eq true
   end
 
-  it "is true if YES" do
+  it "is true if 'YES'" do
     expect("YES".to_bool).to eq true
   end
 


### PR DESCRIPTION
I changed `Symbol#to_bool` to be case-insensitive (e.g. `:TRUE` is true)
And  I included some cosmetic changes.